### PR TITLE
[RFR] disable CSS sourcemap

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "start": "npm-run-all -p watch-css start-js",
     "start-js": "react-scripts start",
     "build-css": "node-sass-chokidar --include-path ./node_modules src/ -o src/",
-    "build-autoprefixed-css": "postcss build/static/css/*.css --replace --use autoprefixer --verbose",
+    "build-autoprefixed-css": "postcss build/static/css/*.css --replace --use autoprefixer --verbose --map false",
     "watch-css": "npm run build-css && node-sass-chokidar --include-path ./node_modules src/ -o src/ --watch --recursive",
     "build-js": "react-scripts build",
     "build": "npm-run-all build-css build-js build-autoprefixed-css",


### PR DESCRIPTION
Will reduce the produced CSS file by 2/3 of its size, eg on a project :

from
```bash
$ ll build/static/css 
-rw-r--r--. 1 1000 1000 327K Feb 20 11:45 main.ce0deb57.css
```

to
```bash
$ ll build/static/css                                       
-rw-r--r--. 1 1000 1000  92K Feb 20 18:25 main.ce0deb57.css
```