### PR TITLE
[RFR] allow console message to be printed during tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "watch-css": "npm run build-css && node-sass-chokidar --include-path ./node_modules src/ -o src/ --watch --recursive",
     "build-js": "react-scripts build",
     "build": "npm-run-all build-css build-js build-autoprefixed-css",
-    "test": "react-scripts test --env=jsdom",
+    "test": "react-scripts test --env=jsdom --verbose false",
     "eject": "react-scripts eject"
   },
   "devDependencies": {


### PR DESCRIPTION
Set the `--verbose false` flag to jest in order to see console.log
messages during tests.

See https://github.com/facebook/jest/issues/2441#issuecomment-445860128