### PR TITLE
Fix tilde import avaibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
   "name": "knp-react-app",
   "version": "0.1.0",
   "dependencies": {
-    "node-sass-tilde-importer": "^1.0.2",
     "ramda": "^0.26.1",
     "react": "^16.8.2",
     "react-dom": "^16.8.2",
@@ -26,6 +25,7 @@
   "devDependencies": {
     "autoprefixer": "^9.4.8",
     "node-sass-chokidar": "^1.3.4",
+    "node-sass-tilde-importer": "^1.0.2",
     "npm-run-all": "^4.1.5",
     "postcss-cli": "^6.1.1",
     "react-scripts": "^2.1.5",

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "knp-react-app",
   "version": "0.1.0",
   "dependencies": {
+    "node-sass-tilde-importer": "^1.0.2",
     "ramda": "^0.26.1",
     "react": "^16.8.2",
     "react-dom": "^16.8.2",

--- a/package.json
+++ b/package.json
@@ -15,9 +15,9 @@
   "scripts": {
     "start": "npm-run-all -p watch-css start-js",
     "start-js": "react-scripts start",
-    "build-css": "node-sass-chokidar --include-path ./node_modules src/ -o src/",
+    "build-css": "node-sass-chokidar --importer=node_modules/node-sass-tilde-importer --include-path ./node_modules src/ -o src/",
     "build-autoprefixed-css": "postcss build/static/css/*.css --replace --use autoprefixer --verbose --map false",
-    "watch-css": "npm run build-css && node-sass-chokidar --include-path ./node_modules src/ -o src/ --watch --recursive",
+    "watch-css": "npm run build-css && node-sass-chokidar --importer=node_modules/node-sass-tilde-importer --include-path ./node_modules src/ -o src/ --watch --recursive",
     "build-js": "react-scripts build",
     "build": "npm-run-all build-css build-js build-autoprefixed-css",
     "test": "react-scripts test --env=jsdom --verbose false",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3887,6 +3887,11 @@ find-cache-dir@^2.0.0:
     make-dir "^1.0.0"
     pkg-dir "^3.0.0"
 
+find-parent-dir@^0.3.0:
+  version "0.3.0"
+  resolved "http://registry.npm.taobao.org/find-parent-dir/download/find-parent-dir-0.3.0.tgz#33c44b429ab2b2f0646299c5f9f718f376ff8d54"
+  integrity sha1-M8RLQpqysvBkYpnF+fcY83b/jVQ=
+
 find-up@3.0.0, find-up@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/find-up/-/find-up-3.0.0.tgz#49169f1d7993430646da61ecc5ae355c21c97b73"
@@ -6563,6 +6568,13 @@ node-sass-chokidar@^1.3.4:
     node-sass "^4.9.3"
     sass-graph "^2.1.1"
     stdout-stream "^1.4.0"
+
+node-sass-tilde-importer@^1.0.2:
+  version "1.0.2"
+  resolved "http://registry.npm.taobao.org/node-sass-tilde-importer/download/node-sass-tilde-importer-1.0.2.tgz#1a15105c153f648323b4347693fdb0f331bad1ce"
+  integrity sha1-GhUQXBU/ZIMjtDR2k/2w8zG60c4=
+  dependencies:
+    find-parent-dir "^0.3.0"
 
 node-sass@^4.9.3:
   version "4.11.0"


### PR DESCRIPTION
According to the CRA official documentation, we could be able to import node_modules using `~` (tilde) : 
> @import '~nprogress/nprogress'; // importing a css file from the nprogress node module
https://facebook.github.io/create-react-app/docs/adding-a-sass-stylesheet

*node-sass-chokidar* break this feature, and it is a little bit annoying.  
I fix it using a workaround with *node-sass-tilde-importer* module.